### PR TITLE
Update like route to use NextRequest

### DIFF
--- a/src/app/api/posts/[id]/like/route.ts
+++ b/src/app/api/posts/[id]/like/route.ts
@@ -1,7 +1,8 @@
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextRequest } from 'next/server'
 
 export async function POST(
-  req: Request,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const supabase = await createServerSupabaseClient();


### PR DESCRIPTION
## Summary
- update posts like route to use NextRequest and keep Response return

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579209c6a4832f8eaed4285bf95c6d