### PR TITLE
Add image URL support to posts API

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -39,7 +39,13 @@ export async function POST(req: Request) {
     });
   }
 
-  const { content } = await req.json();
+  const { content, imageUrl } = await req.json();
+
+  // Normalize empty image strings to null
+  const sanitizedImageUrl =
+    typeof imageUrl === "string" && imageUrl.trim() !== ""
+      ? imageUrl.trim()
+      : null;
 
   if (!content) {
     return new Response(JSON.stringify({ error: "Content is required" }), {
@@ -49,7 +55,7 @@ export async function POST(req: Request) {
 
   const { data, error } = await supabase
     .from("posts")
-    .insert([{ content, author_id: user.id }])
+    .insert([{ content, image_url: sanitizedImageUrl, author_id: user.id }])
     .select();
 
   if (error) {


### PR DESCRIPTION
## Summary
- parse `content` and `imageUrl` from post requests
- normalise an empty `imageUrl` to `null`
- store the `image_url` when creating a post

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857936890b0832f873c97e823a3f1a8